### PR TITLE
Handle open wiki links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "micromark-extension-wiki-link",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micromark-extension-wiki-link",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Parse and render wiki-style links",
   "keywords": [
     "remark",

--- a/test/micromark_test.js
+++ b/test/micromark_test.js
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import micromark from "micromark";
+import micromark from "micromark/lib";
 
 import { syntax, html } from '..';
 
@@ -40,6 +40,35 @@ describe('micromark-extension-wiki-link', () => {
     });
 
     assert.equal(serialized, '<p><a href="#/page/real_page" class="internal new">Page Alias</a></p>');
+  });
+
+  context("open wiki links", () => {
+    it("handles open wiki links", () => {
+      let serialized = micromark('t[[\nt', {
+        extensions: [syntax()],
+        htmlExtensions: [html()]
+      });
+
+      assert.equal(serialized, '<p>t[[\nt</p>');
+    });
+
+    it("handles open wiki links at end of file", () => {
+      let serialized = micromark('t [[', {
+        extensions: [syntax()],
+        htmlExtensions: [html()]
+      });
+
+      assert.equal(serialized, '<p>t [[</p>');
+    });
+
+    it("handles open wiki links with partial data", () => {
+      let serialized = micromark('t [[tt\nt', {
+        extensions: [syntax()],
+        htmlExtensions: [html()]
+      });
+
+      assert.equal(serialized, '<p>t [[tt\nt</p>');
+    });
   });
 
   context("configuration options", () => {


### PR DESCRIPTION
Previously, open wiki links caused an unhandled exception due to not closing tokens. We now
pass through to other tokenizers when there is a newline or we're at the end of the file.
This commit also adjusts some of the `consume` logic to satisfy the assertions in micromark
when running tests with 'micromark/lib'.

* Supersedes https://github.com/landakram/micromark-extension-wiki-link/pull/3
* Relates to https://github.com/landakram/remark-wiki-link/issues/9