### PR TITLE
Handle open link with partial alias and partial alias divider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - '12'
-  - '11'
-  - '10'
-after_success: bash <(curl -s https://codecov.io/bash)
-sudo: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micromark-extension-wiki-link",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Parse and render wiki-style links",
   "keywords": [
     "remark",

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,6 @@ function wikiLink (opts = {}) {
 
     function consumeData (code) {
       if (markdownLineEnding(code) || code === codes.eof) {
-        effects.exit('wikiLink')
         return nok(code)
       }
 
@@ -86,9 +85,6 @@ function wikiLink (opts = {}) {
       }
 
       if (markdownLineEnding(code) || code === codes.eof) {
-        effects.exit('wikiLinkTarget')
-        effects.exit('wikiLinkData')
-        effects.exit('wikiLink')
         return nok(code)
       }
 
@@ -125,6 +121,10 @@ function wikiLink (opts = {}) {
         effects.exit('wikiLinkData')
         effects.enter('wikiLinkMarker')
         return consumeEnd(code)
+      }
+
+      if (markdownLineEnding(code) || code === codes.eof) {
+        return nok(code)
       }
 
       if (!markdownLineEndingOrSpace(code)) {

--- a/test/micromark_test.js
+++ b/test/micromark_test.js
@@ -34,8 +34,8 @@ describe('micromark-extension-wiki-link', () => {
   });
 
   it("handles wiki links with a custom alias divider", () => {
-    let serialized = micromark('[[Real Page|Page Alias]]', {
-      extensions: [syntax({ aliasDivider: "|" })],
+    let serialized = micromark('[[Real Page||Page Alias]]', {
+      extensions: [syntax({ aliasDivider: "||" })],
       htmlExtensions: [html()]
     });
 
@@ -68,6 +68,24 @@ describe('micromark-extension-wiki-link', () => {
       });
 
       assert.equal(serialized, '<p>t [[tt\nt</p>');
+    });
+
+    it("handles open wiki links with partial alias divider", () => {
+      let serialized = micromark('[[t|\nt', {
+        extensions: [syntax({ aliasDivider: "||" })],
+        htmlExtensions: [html()]
+      });
+
+      assert.equal(serialized, '<p>[[t|\nt</p>');
+    });
+
+    it("handles open wiki links with partial alias", () => {
+      let serialized = micromark('[[t:\nt', {
+        extensions: [syntax()],
+        htmlExtensions: [html()]
+      });
+
+      assert.equal(serialized, '<p>[[t:\nt</p>');
     });
   });
 


### PR DESCRIPTION
We missed a few cases for the fix in https://github.com/landakram/micromark-extension-wiki-link/pull/4. Fix these cases and add tests for them.

Also, turns out it is not necessary to close tokens before calling nok, as nok
automatically closes any open tokens and resets the tokenizer state.